### PR TITLE
Updated To Stripe 3.3.4 to allow for stripe connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ try{
 
 This package wraps the methods below. These are all the methods that are listed in the [stripe-node](https://github.com/stripe/stripe-node) github documentation.
 
- * account
+ * accounts
+  * [`create(params)`](https://stripe.com/docs/api/node#create_account)
   * [`retrieve()`](https://stripe.com/docs/api/node#retrieve_account)
+  * [`update(accountId[, params])`](https://stripe.com/docs/api/node#update_account)
+  * [`list([params])`](https://stripe.com/docs/api/node#list_accounts)
  * balance
   * [`retrieve()`](https://stripe.com/docs/api/node#retrieve_balance)
   * [`listTransactions([params])`](https://stripe.com/docs/api/node#balance_history)

--- a/StripeSync.js
+++ b/StripeSync.js
@@ -1,32 +1,33 @@
-StripeSync = function(key){
-    var Stripe;
-    var resources = {
-        account:["retrieve"],
-        balance:["retrieve", "listTransactions", "retrieveTransaction"],
-        charges:["create", "list", "retrieve", "capture", "refund", "update", "updateDispute", "closeDispute", "setMetadata", "getMetadata"],
-        coupons:["create", "list", "retrieve", "del"],
-        customers:["create", "list", "update", "retrieve", "del", "setMetaData", "getMetadata", "createSubscription", "updateSubscription", "cancelSubscription", "listSubscriptions", "createCard", "listCards", "retrieveCard", "updateCard", "deleteCard", "deleteDiscount"],
-        events:["list", "retrieve"],
-        invoiceItems:["create", "list", "update", "retrieve", "del"],
-        invoices:["create", "list", "update", "retrieve", "retrieveLines", "retrieveUpcoming", "pay"],
-        plans:["create", "list", "update", "retrieve", "del"],
-        recipients:["create", "list", "update", "retrieve", "del", "setMetadata", "getMetadata"],
-        tokens:["create", "retrieve"],
-        transfers:["create", "list", "retrieve", "update", "cancel", "listTransactions", "setMetadata", "getMetadata"]
-    };
+StripeSync = function (key){
+  var Stripe;
+  var resources = {
+    account:["create", "list", "update", "retrieve"],
+    accounts:["create", "list", "update", "retrieve"],
+    balance:["retrieve", "listTransactions", "retrieveTransaction"],
+    charges:["create", "list", "retrieve", "capture", "refund", "update", "updateDispute", "closeDispute", "setMetadata", "getMetadata"],
+    coupons:["create", "list", "retrieve", "del"],
+    customers:["create", "list", "update", "retrieve", "del", "setMetaData", "getMetadata", "createSubscription", "updateSubscription", "cancelSubscription", "listSubscriptions", "createCard", "listCards", "retrieveCard", "updateCard", "deleteCard", "deleteDiscount"],
+    events:["list", "retrieve"],
+    invoiceItems:["create", "list", "update", "retrieve", "del"],
+    invoices:["create", "list", "update", "retrieve", "retrieveLines", "retrieveUpcoming", "pay"],
+    plans:["create", "list", "update", "retrieve", "del"],
+    recipients:["create", "list", "update", "retrieve", "del", "setMetadata", "getMetadata"],
+    tokens:["create", "retrieve"],
+    transfers:["create", "list", "retrieve", "update", "cancel", "listTransactions", "setMetadata", "getMetadata"]
+  };
 
-    if(!StripeAPI){
-        throw new Error("StripeSync package requires one of the following packages: mrgalaxy:stripe, grove:stripe-npm\nOR another package that exposes stripe-node as StripeAPI(key)");
-    }
+  if(!StripeAPI){
+    throw new Error("StripeSync package requires one of the following packages: mrgalaxy:stripe, grove:stripe-npm\nOR another package that exposes stripe-node as StripeAPI(key)");
+  }
 
-    Stripe = StripeAPI(key);
+  Stripe = StripeAPI(key);
 
-    _.each(resources, function(resource, key){
-        _.each(resource, function(funcName){
-            var stripeFunc = Stripe[key][funcName];
-            Stripe[key][funcName] = Meteor.wrapAsync(stripeFunc, Stripe[key]);
-        });
+  _.each(resources, function (resource, key){
+    _.each(resource, function (funcName){
+      var stripeFunc = Stripe[key][funcName];
+      Stripe[key][funcName] = Meteor.wrapAsync(stripeFunc, Stripe[key]);
     });
+  });
 
-    return Stripe;
+  return Stripe;
 };


### PR DESCRIPTION
With Stripe 3.4.4 we now have the ability to use Stripe Connect which
is used for market places to charge a card and deposit funds into a
service providers account with one API call. These updates will allow
for these changes to take place. The required changes for
grovelabs/meteor-stripe-npm have already been committed and merged.
